### PR TITLE
Adding Multitenant Wallet Authorization

### DIFF
--- a/endorser/api/acapy_utils.py
+++ b/endorser/api/acapy_utils.py
@@ -20,7 +20,7 @@ def get_acapy_headers(headers=None, tenant=False) -> dict:
     if settings.ACAPY_ADMIN_URL_API_KEY:
         headers["X-API-Key"] = settings.ACAPY_ADMIN_URL_API_KEY
     if settings.ACAPY_WALLET_AUTH_TOKEN:
-        headers["Authorization"] = settings.ACAPY_WALLET_AUTH_TOKEN
+        headers["Authorization"] = "Bearer " + settings.ACAPY_WALLET_AUTH_TOKEN
     return headers
 
 

--- a/endorser/api/acapy_utils.py
+++ b/endorser/api/acapy_utils.py
@@ -19,6 +19,8 @@ def get_acapy_headers(headers=None, tenant=False) -> dict:
         headers["Content-Type"] = "application/json"
     if settings.ACAPY_ADMIN_URL_API_KEY:
         headers["X-API-Key"] = settings.ACAPY_ADMIN_URL_API_KEY
+    if settings.ACAPY_WALLET_AUTH_TOKEN:
+        headers["Authorization"] = settings.ACAPY_WALLET_AUTH_TOKEN
     return headers
 
 

--- a/endorser/api/core/config.py
+++ b/endorser/api/core/config.py
@@ -83,7 +83,7 @@ class GlobalConfig(BaseSettings):
 
     ACAPY_ADMIN_URL: str = os.environ.get("ACAPY_ADMIN_URL", "http://localhost:9031")
     ACAPY_ADMIN_URL_API_KEY: str = os.environ.get("ACAPY_API_ADMIN_KEY", "change-me")
-    ACAPY_WALLET_AUTH_TOKEN: str = os.environ.get("ACAPY_WALLET_AUTH_TOKEN","")
+    ACAPY_WALLET_AUTH_TOKEN: str = os.environ.get("ACAPY_WALLET_AUTH_TOKEN")
 
     ENDORSER_API_ADMIN_USER: str = os.environ.get("ENDORSER_API_ADMIN_USER", "endorser")
     ENDORSER_API_ADMIN_KEY: str = os.environ.get("ENDORSER_API_ADMIN_KEY", "change-me")

--- a/endorser/api/core/config.py
+++ b/endorser/api/core/config.py
@@ -83,6 +83,7 @@ class GlobalConfig(BaseSettings):
 
     ACAPY_ADMIN_URL: str = os.environ.get("ACAPY_ADMIN_URL", "http://localhost:9031")
     ACAPY_ADMIN_URL_API_KEY: str = os.environ.get("ACAPY_API_ADMIN_KEY", "change-me")
+    ACAPY_WALLET_AUTH_TOKEN: str = os.environ.get("ACAPY_WALLET_AUTH_TOKEN","")
 
     ENDORSER_API_ADMIN_USER: str = os.environ.get("ENDORSER_API_ADMIN_USER", "endorser")
     ENDORSER_API_ADMIN_KEY: str = os.environ.get("ENDORSER_API_ADMIN_KEY", "change-me")


### PR DESCRIPTION
This is to add support when using multi-tenant endorser AcaPy agent. Adding a setting ACAPY_WALLET_AUTH_TOKEN, where the wallet token needs to be given in the format "Bearer `<TOKEN>`". When this setting is passed through an environment variable, "Authorization" header is added to the API call.