### PR TITLE
--log-level is already set in dockerCompose variable

### DIFF
--- a/docker/manage
+++ b/docker/manage
@@ -189,8 +189,7 @@ function logs() {
     (( no_tail != 1 )) && log_args+=( '-f' )
     if [ ! -z "${TAIL_LOGS}" ] || [ ! -z "${_force}" ]; then
       ${dockerCompose} \
-        --log-level ERROR logs \
-         "${log_args[@]}" "$@"
+        logs "${log_args[@]}" "$@"
     fi
   )
 }


### PR DESCRIPTION
Prevents a `unknown flag: --log-level` error when starting endorser