### PR TITLE
Update agent image.

### DIFF
--- a/docker/acapy/Dockerfile.acapy
+++ b/docker/acapy/Dockerfile.acapy
@@ -1,4 +1,4 @@
-FROM bcgovimages/aries-cloudagent:py36-1.16-1_1.0.0-rc1
+FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.10.3
 
 USER root
 


### PR DESCRIPTION
Switch to official askar only image, and update to `0.10.3`.

The previous agent version, 1.0.0-rc-0 is incompatible with ACA-Py >=1.10.1.  See https://github.com/hyperledger/aries-cloudagent-python/issues/2528