### PR TITLE
Update maintainers list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,6 +11,8 @@
 | Ian Costanzo     | ianco            | ianco            |
 | Stephen Curran   | swcurran         | swcurran         |
 | Wade Barnes      | WadeBarnes       | WadeBarnes       |
+| Emiliano Sune    | esune            | esune            |
+| Gavin Freeborn   | gavinok          |                  |
 
 ## Becoming a Maintainer
 


### PR DESCRIPTION
Suggesting the following change (additions) to the maintainers list:

- @esune  (myself) as I have been designing the enhancements to the endorser service required to automate some/all of the endorsement operations with fine-grained control
- @Gavinok as he has been the hands-on implementer of the above changes (see #34)