### PR TITLE
Add ngrok setup and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ ENDORSER_SEED=<your 32 char seed> ./manage start --logs
 
 By default, the `./manage` script will start an ngrok process to expose the Endorser agent's endpoint, and the Endorser agent will use the ngrok URL when publishing their endpoint.
 
+### Auth
+
+Each developer must apply for an Ngrok token [here](https://dashboard.ngrok.com/get-started/your-authtoken). Then place the token into an `.env` file within the **docker** directory with the contents below.
+
+```
+NGROK_AUTH=<your token here>
+```
+
+### Bypassing Ngrok
+
 If you don't want to do this (or if ngrok isn't workin' for ya) you can override this behaviour - just set environment variable `ENDORSER_ENV` to something other than `local`, and then set `ACAPY_ENDPOINT` explicitly.
 
 For example, to startup the Endorser to run exclusively within a docker network (for example to run the BDD tests ...  see later section ...):

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,9 +31,10 @@ services:
     environment:
       - CADDY_AGENT_PORT=${CADDY_AGENT_PORT}
       - CADDY_HOST=${CADDY_HOST}
+      - NGROK_AUTH=${NGROK_AUTH}
     ports:
       - ${NGROK_ENDORSER_AGENT_PORT_EXPOSED}:${NGROK_ENDORSER_AGENT_PORT}
-    command: ngrok http ${CADDY_HOST}:${CADDY_AGENT_PORT} --log stdout
+    command: ngrok http ${CADDY_HOST}:${CADDY_AGENT_PORT} --authtoken ${NGROK_AUTH} --log stdout
 
   aries-endorser-agent:
     build:


### PR DESCRIPTION
These days one needs a token to use Ngrok. Starting up the endorser service locally is failing currently with the existing instructions.

Add instructions to add your token to an `env` and import that into the ngrok container.

As a note, most of the other stuff in our ecosystem I believe uses `ngrok/ngrok` as the image whereas this one is still using `image: wernight/ngrok`. Might be a task for later to reconcile that?