### PR TITLE
Change docker compose to the ngrok/ngrok image

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ By default, the `./manage` script will start an ngrok process to expose the Endo
 Each developer must apply for an Ngrok token [here](https://dashboard.ngrok.com/get-started/your-authtoken). Then place the token into an `.env` file within the **docker** directory with the contents below.
 
 ```
-NGROK_AUTH=<your token here>
+NGROK_AUTHTOKEN=<your token here>
 ```
 
 ### Bypassing Ngrok

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,14 +27,14 @@ services:
       retries: 5
 
   ngrok-endorser-agent:
-    image: wernight/ngrok
+    image: ngrok/ngrok
     environment:
       - CADDY_AGENT_PORT=${CADDY_AGENT_PORT}
       - CADDY_HOST=${CADDY_HOST}
-      - NGROK_AUTH=${NGROK_AUTH}
+      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}
     ports:
       - ${NGROK_ENDORSER_AGENT_PORT_EXPOSED}:${NGROK_ENDORSER_AGENT_PORT}
-    command: ngrok http ${CADDY_HOST}:${CADDY_AGENT_PORT} --authtoken ${NGROK_AUTH} --log stdout
+    command: http ${CADDY_HOST}:${CADDY_AGENT_PORT} --log stdout
 
   aries-endorser-agent:
     build:


### PR DESCRIPTION
The `wernight/ngrok` image is out of date and you can get Ngrok token errors with the age of the agent.

Update to the `ngrok/ngrok` that is used elsewhere in the hyperledger and aca-py ecosystems. 