### PR TITLE
Corrected handling of booleans in csv's to better work with tests

### DIFF
--- a/bdd-tests/features/steps/author-endorsements.py
+++ b/bdd-tests/features/steps/author-endorsements.py
@@ -87,8 +87,8 @@ from util import (
 )
 
 
-@when('the endorser allows "{author}" last schema from file via {POST_or_PUT}')
-@then('the endorser allows "{author}" last schema from file via {POST_or_PUT}')
+@when('the endorser allows "{author}" last schema from file via "{POST_or_PUT}"')
+@then('the endorser allows "{author}" last schema from file via "{POST_or_PUT}"')
 def step_impl(context, author: str, POST_or_PUT: Literal["POST"] | Literal["PUT"]):
     schema = get_author_context(context, author, "current_schema")
     resp = call_author_service(
@@ -257,10 +257,10 @@ def step_impl(context, author: str, with_or_without: str):
 
 
 @then(
-    'the endorser allows "{author}" last credential definition "{with_or_without}" revocation support from file via {POST_or_PUT}'
+    'the endorser allows "{author}" last credential definition "{with_or_without}" revocation support from file via "{POST_or_PUT}"'
 )
 @when(
-    'the endorser allows "{author}" last credential definition "{with_or_without}" revocation support from file via {POST_or_PUT}'
+    'the endorser allows "{author}" last credential definition "{with_or_without}" revocation support from file via "{POST_or_PUT}"'
 )
 def step_impl(
     context,

--- a/endorser/api/endpoints/routes/allow.py
+++ b/endorser/api/endpoints/routes/allow.py
@@ -334,11 +334,35 @@ async def delete_allowed_cred_def(
         raise HTTPException(status_code=db_to_http_exception(e), detail=str(e))
 
 
+def maybe_str_to_bool(s: str) -> str | bool:
+    return s == "True" if isinstance(s, str) else s
+
+
+def construct_allowed_credential_definition(cd):
+    return AllowedCredentialDefinition(
+        issuer_did=f"{cd['issuer_did']}",
+        author_did=f"{cd['author_did']}",
+        schema_name=f"{cd['schema_name']}",
+        version=f"{cd['version']}",
+        tag=f"{cd['tag']}",
+        rev_reg_def=maybe_str_to_bool(cd["rev_reg_def"]),
+        rev_reg_entry=maybe_str_to_bool(cd["rev_reg_entry"]),
+    )
+
+
 async def update_allowed_config(k, v, db):
     csvReader = DictReader(iterdecode(k.file, "utf-8"))
+    constructed_classes = [
+        (
+            construct_allowed_credential_definition(i)
+            if v is AllowedCredentialDefinition
+            else v(**i)
+        )
+        for i in csvReader
+    ]
     tmp = {
         "file_name": k.filename,
-        "contents": [v(**i) for i in csvReader],
+        "contents": constructed_classes,
     }
     for i in tmp["contents"]:
         db.add(i)


### PR DESCRIPTION
This PR resolves #100 

The issue was due to the True in csv's being interpreted as strings causing a type error. This is now manually checked beforehand to allow the tests to work as expected.